### PR TITLE
Fix race condition that could break output when flattening lists-of-lists 

### DIFF
--- a/api/backend_load.go
+++ b/api/backend_load.go
@@ -179,7 +179,6 @@ func flattenedIndexedLists(data map[string]any) {
 			arraysToFlatten = append(arraysToFlatten, arrayToFlatten{key: k, array: arr})
 		}
 	}
-	fmt.Println("==>", arraysToFlatten)
 
 	// Second pass: flatten all collected arrays
 	var mapsToProcess []map[string]any

--- a/api/backend_load.go
+++ b/api/backend_load.go
@@ -159,7 +159,6 @@ func newDiscoveryHandler(req ConfigurationRequest, source *Source) discoveryHand
 			Name:   f.FullyQualifiedName(),
 			Source: mapStructuredData,
 		}
-		//fmt.Println("==>", ps)
 
 		source.PropertySources = append(source.PropertySources, ps)
 		return nil


### PR DESCRIPTION
Roughly 50% of the time I was seeing broken output when using a configuration containing a list of lists.

This is a result of the recursive algorithm and Go's indeterminate map iteration. Basically, we discover the deeper list before the shallower one, and this confuses things.

New approach introduces two passes, so that the recursion can be done inside the determinate iteration of a slice.

Net result, 100% success